### PR TITLE
修复选择食物问题。opencv rgb函数方面采用wydy提出的cap函数，可以先merge wydy的版本。

### DIFF
--- a/fisher/environment.py
+++ b/fisher/environment.py
@@ -92,10 +92,16 @@ class FishFind:
         time.sleep(1)
         pyautogui.click(1650, 790, button=pyautogui.SECONDARY)
         time.sleep(0.5)
-        bbox_food = match_img(cap(self.food_rgn), self.food_imgs[self.ff_dict[fish_type]], type=cv2.TM_CCORR_NORMED)
+        bbox_food = match_img(cap(self.food_rgn,fmt='RGB'), self.food_imgs[self.ff_dict[fish_type]], type=cv2.TM_CCORR_NORMED)
         pyautogui.click(bbox_food[4]+self.food_rgn[0], bbox_food[5]+self.food_rgn[1])
+        time.sleep(0.5)
+        error_repeat_std_color = [48, 43, 41]
+        if np.mean(np.abs(cap(self.food_rgn)[219][739]-error_repeat_std_color))<5:
+            pyautogui.click(1300, 756)
+            time.sleep(0.1)
+        
         time.sleep(0.1)
-        pyautogui.click(1183, 756)
+        pyautogui.click(1300, 756)
 
     def do_fish(self, fish_init=True) -> bool:
         if fish_init:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -23,7 +23,7 @@ with open(CONFIG_PATH, encoding='utf-8') as f:
 #     return cv2.cvtColor(np.asarray(img), cv2.COLOR_RGB2BGR)
 
 
-def cap(region=None):
+def cap(region=None ,fmt='RGB'):
     if region is not None:
         left, top, w, h = region
         # w = x2 - left + 1
@@ -56,7 +56,12 @@ def cap(region=None):
     win32gui.ReleaseDC(hwnd, wDC)
     win32gui.DeleteObject(dataBitMap.GetHandle())
 
-    return cv2.cvtColor(np.asarray(img), cv2.COLOR_RGB2BGR)
+    if fmt == 'BGR':
+        return cv2.cvtColor(np.asarray(img), cv2.COLOR_RGBA2BGR)
+    if fmt == 'RGB':
+        return cv2.cvtColor(np.asarray(img), cv2.COLOR_RGBA2RGB)
+    else:
+        raise ValueError('Cannot indetify this fmt')
 
 
 def mouse_down(x, y):


### PR DESCRIPTION
选择食物问题：可能因为跟初始选择的食物重复，而导致点出食物详细信息页面，使得后面的程序失效。
具体修复方法：在选择食物函数中，判断是否点出食物详细信息页面，若点出，则再次点击，取消食物详细信息页面。